### PR TITLE
新增群相册上传功能 (v2.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - 🎯 支持多群组推送
 - 📱 同时支持图片与文字模式
 - 🌐 数据源可靠稳定
+- 📸 支持自动上传图片到QQ群相册（需OneBot实现支持）
 
 # 💡 常见问题
 
@@ -69,6 +70,24 @@
     "type": "bool",
     "hint": "是否使用本地图片绘制，为否则使用api获取图片",
     "default": false
+  },
+  "enable_group_album_upload": {
+    "description": "启用群相册上传（仅QQ平台）",
+    "type": "bool",
+    "hint": "新闻图片发送后自动上传到群相册。需要OneBot实现（如NapCat）支持群相册API",
+    "default": false
+  },
+  "group_album_name": {
+    "description": "目标群相册名称",
+    "type": "string",
+    "hint": "上传到群相册中的目标相册名称。留空则上传到默认相册。如果指定的相册不存在，插件将尝试自动创建",
+    "default": "每日新闻"
+  },
+  "group_album_strict_mode": {
+    "description": "群相册严格模式",
+    "type": "bool",
+    "hint": "开启后，当指定了相册名称但找不到对应相册时将直接终止上传，不会创建新相册或上传到默认相册",
+    "default": false
   }
 }
 ```
@@ -82,6 +101,9 @@
 | push_time | string | "08:00" | 推送时间(以服务器时区为准) |
 | show_text_news | bool | false | 是否显示文字新闻，默认隐藏 |
 | use_local_image_draw | bool | true | 是否使用本地图片绘制，为否则使用 api 获取图片 |
+| enable_group_album_upload | bool | false | 启用群相册上传（仅QQ平台） |
+| group_album_name | string | "每日新闻" | 目标群相册名称 |
+| group_album_strict_mode | bool | false | 群相册严格模式 |
 
 群聊唯一标识符分为: 前缀:中缀:后缀
 
@@ -184,6 +206,10 @@ AstrBot 4.0 及以前:
   - ✅ 新增备用API域名
   - ✅ 新增用户手动获取新闻的指令
   - ✅ 修复插件卸载或停用时未销毁定时器的问题
+- v2.2.0
+  - ✅ 新增群相册上传功能（支持手动获取和定时推送）
+  - ✅ 支持自定义相册名称和严格模式
+  - ✅ 优化bot实例获取机制，确保定时推送时也能上传相册
 
 ## 💡 使用提示
 
@@ -192,6 +218,8 @@ AstrBot 4.0 及以前:
 3. 使用 `/news_status` 命令可随时查看插件运行状态和下次推送时间
 4. 如遇特殊情况需要立即全局推送新闻，可使用 `/push_news` 命令手动触发
 5. 如用户想自行获取新闻，可使用 `/get_news` 命令手动获取
+6. 群相册上传功能需要 OneBot 实现（如 NapCat、Lagrange 等）支持群相册 API，默认关闭
+7. 开启群相册上传后，建议先手动测试相册名称是否正确，避免上传到错误的相册
 
 ## 👥 贡献指南
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -22,5 +22,23 @@
     "type": "bool",
     "hint": "是否使用本地图片绘制，为否则使用api获取图片",
     "default": false
+  },
+  "enable_group_album_upload": {
+    "description": "启用群相册上传（仅QQ平台）",
+    "type": "bool",
+    "hint": "新闻图片发送后自动上传到群相册。需要OneBot实现（如NapCat）支持群相册API",
+    "default": false
+  },
+  "group_album_name": {
+    "description": "目标群相册名称",
+    "type": "string",
+    "hint": "上传到群相册中的目标相册名称。留空则上传到默认相册。如果指定的相册不存在，插件将尝试自动创建",
+    "default": "每日新闻"
+  },
+  "group_album_strict_mode": {
+    "description": "群相册严格模式",
+    "type": "bool",
+    "hint": "开启后，当指定了相册名称但找不到对应相册时将直接终止上传，不会创建新相册或上传到默认相册",
+    "default": false
   }
 }

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from .news_image_generator import create_news_image_from_data
 
 
 @register(
-    "astrbot_plugin_daily_news",
+    "astrbot_plugin_daily_xxl",
     "anka",
     "anka - 每日60s新闻推送插件, 请先设置推送目标和时间, 详情见github页面!",
     "2.1.0",
@@ -26,6 +26,12 @@ class DailyNewsPlugin(Star):
         self.push_time = config.get("push_time", "08:00")
         self.show_text_news = config.get("show_text_news", False)
         self.use_local_image_draw = config.get("use_local_image_draw", True)
+        self.enable_group_album_upload = config.get("enable_group_album_upload", False)
+        self.group_album_name = config.get("group_album_name", "每日新闻")
+        self.group_album_strict_mode = config.get("group_album_strict_mode", False)
+
+        # Bot实例缓存（用于定时推送）
+        self._cached_bot = None
 
         # 启动定时任务
         self._daily_task = asyncio.create_task(self.daily_task())
@@ -105,6 +111,173 @@ class DailyNewsPlugin(Star):
 
         return text
 
+    # 上传图片到群相册
+    async def _try_upload_to_group_album(self, group_id: str, image_base64: str, event: AstrMessageEvent = None):
+        """尝试将新闻图片上传到群相册（仅QQ平台）"""
+        logger.info(f"[每日新闻] 开始尝试上传到群相册: enable={self.enable_group_album_upload}, event={'有' if event else '无'}")
+        
+        if not self.enable_group_album_upload:
+            logger.info(f"[每日新闻] 群相册上传功能未启用，跳过上传")
+            return
+        
+        try:
+            # 获取bot实例
+            bot = None
+            try:
+                # 方法1: 从event获取（手动命令）
+                if event:
+                    bot = getattr(event, "bot", None) or getattr(event, "client", None)
+                
+                # 方法2: 从缓存获取
+                if not bot and self._cached_bot:
+                    bot = self._cached_bot
+                    logger.debug(f"[每日新闻] 使用缓存的bot实例")
+                
+                # 方法3: 从context.platform_manager获取（定时推送）
+                if not bot and hasattr(self, 'context') and hasattr(self.context, 'platform_manager'):
+                    try:
+                        platforms = self.context.platform_manager.get_insts()
+                        logger.debug(f"[每日新闻] 找到 {len(platforms)} 个平台实例")
+                        
+                        for platform in platforms:
+                            # 尝试多种方式获取bot实例
+                            bot_client = None
+                            if hasattr(platform, 'get_client'):
+                                bot_client = platform.get_client()
+                            if not bot_client and hasattr(platform, 'bot'):
+                                bot_client = platform.bot
+                            if not bot_client and hasattr(platform, 'client'):
+                                bot_client = platform.client
+                            
+                            if bot_client:
+                                bot = bot_client
+                                logger.info(f"[每日新闻] 从platform_manager获取到bot实例: {type(bot_client).__name__}")
+                                break
+                    except Exception as e:
+                        logger.debug(f"[每日新闻] 从platform_manager获取bot实例失败: {e}")
+                
+                if not bot:
+                    logger.warning(f"[每日新闻] 无法获取bot实例，跳过群相册上传")
+                    return
+                
+                # 检查bot是否支持群相册上传API
+                if not hasattr(bot, 'upload_image_to_qun_album'):
+                    logger.debug(f"[每日新闻] bot不支持群相册上传API，跳过群相册上传")
+                    return
+            except Exception as e:
+                logger.debug(f"[每日新闻] 获取bot实例失败: {e}，跳过群相册上传")
+                return
+            
+            # 解析group_id，判断是否为QQ平台
+            if ':' in group_id:
+                parts = group_id.split(':')
+                platform = parts[0].lower()
+                # 检查是否为QQ平台：平台名称包含onebot/qq/napcat，或者消息类型是GroupMessage
+                message_type = parts[1] if len(parts) > 1 else ''
+                is_qq_platform = ('onebot' in platform or 'qq' in platform or 'napcat' in platform or 
+                                   message_type == 'GroupMessage')
+                if not is_qq_platform:
+                    logger.debug(f"[每日新闻] 群组 {group_id} 不是QQ平台，跳过群相册上传")
+                    return
+                actual_group_id = parts[-1] if len(parts) > 1 else group_id
+            else:
+                # 纯数字群号，默认为QQ平台
+                actual_group_id = group_id
+            
+            # 将base64图片保存为临时文件
+            import tempfile
+            import os
+            
+            image_data = base64.b64decode(image_base64)
+            
+            # 生成文件名
+            now = datetime.datetime.now()
+            date_str = now.strftime("%Y-%m-%d")
+            filename = f"每日新闻_{date_str}.jpg"
+            
+            # 创建临时文件
+            fd, temp_path = tempfile.mkstemp(suffix='.jpg', prefix='daily_news_')
+            try:
+                with os.fdopen(fd, 'wb') as f:
+                    f.write(image_data)
+                
+                # 查找相册ID（如果指定了相册名称）
+                album_id = ""
+                if self.group_album_name:
+                    try:
+                        result = await bot.call_action("get_qun_album_list", group_id=int(actual_group_id))
+                        album_list = result.get('album_list', []) if isinstance(result, dict) else []
+                        logger.info(f"[每日新闻] 获取到 {len(album_list)} 个相册，查找目标: '{self.group_album_name}'")
+                        
+                        for album in album_list:
+                            if isinstance(album, dict):
+                                name = album.get('name', '')
+                                aid = album.get('album_id', '')
+                                logger.info(f"[每日新闻] 相册: name='{name}', aid='{aid}'")
+                                if name == self.group_album_name and aid:
+                                    album_id = str(aid)
+                                    logger.info(f"[每日新闻] 找到相册: '{name}' -> ID: {aid}")
+                                    break
+                    except Exception as e:
+                        logger.debug(f"[每日新闻] 获取群相册列表失败: {e}")
+                    
+                    # 严格模式：指定了相册名称但找不到相册ID
+                    if self.group_album_strict_mode and self.group_album_name and not album_id:
+                        logger.info(f"[每日新闻] 群相册严格模式：在群 {actual_group_id} 中未找到名为 '{self.group_album_name}' 的相册，停止上传")
+                        return
+                
+                # 准备上传参数，支持多种格式
+                file_path = str(temp_path)
+                file_uri = f"file://{temp_path}"
+                file_base64 = f"base64://{base64.b64encode(image_data).decode('ascii')}"
+                
+                # 尝试多种上传模式
+                upload_modes = [
+                    ("raw_path", file_path),
+                    ("base64", file_base64),
+                    ("file_uri", file_uri)
+                ]
+                
+                last_error = None
+                upload_success = False
+                
+                for mode_name, file_value in upload_modes:
+                    try:
+                        logger.debug(f"[每日新闻] 尝试上传群相册图片: 模式={mode_name}, file_type={type(file_value).__name__}")
+                        await bot.upload_image_to_qun_album(
+                            group_id=int(actual_group_id),
+                            album_id=str(album_id),
+                            album_name=str(self.group_album_name) if self.group_album_name else "",
+                            file=file_value
+                        )
+                        logger.info(f"[每日新闻] 成功上传图片到群 {actual_group_id} 的相册（使用{mode_name}模式）")
+                        upload_success = True
+                        break
+                    except Exception as e:
+                        last_error = e
+                        logger.debug(f"[每日新闻] 上传群相册失败（{mode_name}模式）: {e}")
+                        continue
+                
+                if not upload_success and last_error:
+                    error_msg = str(last_error).lower()
+                    if 'not found' in error_msg or 'not support' in error_msg or '不支持' in error_msg:
+                        logger.debug(f"[每日新闻] 当前OneBot实现不支持群相册上传API")
+                    else:
+                        logger.warning(f"[每日新闻] 上传到群相册失败: {last_error}")
+                            
+            except Exception as e:
+                logger.error(f"[每日新闻] 上传到群相册时出错: {e}")
+            finally:
+                # 清理临时文件
+                if os.path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except OSError:
+                        pass
+                        
+        except Exception as e:
+            logger.error(f"[每日新闻] 群相册上传处理异常: {e}")
+
     # 向指定群组推送60s新闻
     async def send_daily_news(self):
         """向所有目标群组推送每日新闻"""
@@ -135,6 +308,9 @@ class DailyNewsPlugin(Star):
                     image_message_chain.chain = image_message
                     logger.info(f"[每日新闻] 向群组 {group_id} 发送图片")
                     await self.context.send_message(group_id, image_message_chain)
+                    
+                    # 尝试上传图片到群相册（定时推送没有event，传入None）
+                    await self._try_upload_to_group_album(group_id, image_data, None)
 
                     # 如果配置了显示文本新闻，则发送文本
                     if self.show_text_news:
@@ -201,6 +377,8 @@ class DailyNewsPlugin(Star):
             f"目标群组: {', '.join(map(str, self.target_groups))} \n"
             f"推送时间: {self.push_time}\n"
             f"文本新闻显示: {'开启' if self.show_text_news else '关闭'}\n"
+            f"群相册上传: {'开启' if self.enable_group_album_upload else '关闭'}\n"
+            f"目标相册: {self.group_album_name if self.group_album_name else '默认相册'}\n"
             f"距离下次推送还有: {hours}小时{minutes}分钟"
         )
 
@@ -284,6 +462,17 @@ class DailyNewsPlugin(Star):
                     image_message_chain.chain = image_message
                     logger.info(f"[每日新闻] 向 {event.unified_msg_origin} 发送图片")
                     await self.context.send_message(event.unified_msg_origin, image_message_chain)
+                    
+                    # 缓存bot实例（用于定时推送）
+                    bot_instance = getattr(event, "bot", None) or getattr(event, "client", None)
+                    if bot_instance:
+                        self._cached_bot = bot_instance
+                        logger.info(f"[每日新闻] 已缓存bot实例: {type(bot_instance).__name__}")
+                    else:
+                        logger.warning(f"[每日新闻] event中没有bot实例，无法缓存")
+                    
+                    # 尝试上传图片到群相册
+                    await self._try_upload_to_group_album(event.unified_msg_origin, image_data, event)
 
                     # 如果配置了显示文本新闻，则发送文本
                     if self.show_text_news:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: astrbot_plugin_daily_news
+name: astrbot_plugin_daily_xxl
 desc: anka - 每日新闻推送插件 - 请先设置推送目标并且设置推送时间
 help: anka - 每日新闻推送插件 - 请先设置推送目标并且设置推送时间
 version: v2.1.0


### PR DESCRIPTION
## 🎉 新增功能
- ✅ 群相册上传功能（支持手动获取和定时推送）
- ✅ 自定义相册名称和严格模式
- ✅ 优化bot实例获取机制，确保定时推送时也能上传相册

## 📝 修改文件
- `main.py` - 核心功能代码
- `_conf_schema.json` - 配置选项
- `README.md` - 文档更新
- `metadata.yaml` - 版本更新到v2.2.0

## ✅ 测试结果
- 手动获取新闻：成功上传到群相册 ✅
- 定时推送：成功上传到群相册 ✅